### PR TITLE
Fix returning an API Key that was size + 1.

### DIFF
--- a/lib/key_utilities.rb
+++ b/lib/key_utilities.rb
@@ -3,7 +3,7 @@ module KeyUtilities
   # generates a database unique api key
   def generate_api_key(size = 16)
     alphanumerics = ('0'..'9').to_a + ('A'..'Z').to_a
-    k = (0..size).map {alphanumerics[Kernel.rand(36)]}.join
+    k = (0..(size - 1)).map {alphanumerics[Kernel.rand(36)]}.join
   
     # if key exists in database, regenerate key
     k = generate_api_key if ApiKey.find_by_api_key(k)


### PR DESCRIPTION
When trying to create a new channel using PostgreSQL as a database I was getting a database error that api_key's value was too long for type character varying(16).

Looking into the code I found that  generate_api_key has an instance of 0..size which iterates through size + 1 elements. So asking for an API Key that was 16 characters long was actually returning a string of 17 characters. This broke trying to shove it into a varchar(16) in PostgreSQL.

This patch ensures that only size characters are returned.
