### PR TITLE
fix "Template Not Found" error

### DIFF
--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -24,20 +24,21 @@ class StatusController < ApplicationController
 
 			# set output correctly
 			if params[:format] == 'xml'
-				@channel_xml = @channel.to_xml(channel_options).sub('</channel>', '').strip
-				@feed_xml = @feeds.to_xml(:skip_instruct => true).gsub(/\n/, "\n  ").chop.chop
+				@channel_output = @channel.to_xml(channel_options).sub('</channel>', '').strip
+				@feed_output = @feeds.to_xml(:skip_instruct => true).gsub(/\n/, "\n  ").chop.chop
 			elsif params[:format] == 'csv'
 				@csv_headers = [:created_at, :status]
+				@feed_output = @feeds
 			else
-				@channel_json = @channel.to_json(channel_options).chop
-				@feed_json = @feeds.to_json
+				@channel_output = @channel.to_json(channel_options).chop
+				@feed_output = @feeds.to_json
 			end
 		# else set error code
 		else
 			if params[:format] == 'xml'
-				@channel_xml = bad_channel_xml
+				@channel_output = bad_channel_xml
 			else
-				@channel_json = '-1'.to_json
+				@channel_output = '-1'.to_json
 			end
 		end
 
@@ -46,10 +47,10 @@ class StatusController < ApplicationController
 
 		# output data in proper format
 		respond_to do |format|
-			format.html { render :text => @feed_json }
-			format.json { render :action => 'feed/index' }
-			format.xml { render :action => 'feed/index' }
-			format.csv { render :action => 'feed/index' }
+			format.html { render :text => @feed_output }
+			format.json { render "feed/index" }
+			format.xml { render "feed/index" }
+			format.csv { render "feed/index" }
 		end
 	end
 


### PR DESCRIPTION
This fixes an error in which GET requests to /channels/<channel_id>/status.(format) fail with a "Template Not Found" error for JSON, CSV, and XML formats.

The status controller was previously requesting templates from ./app/views/status/feed/index and /app/views/application/feed/index, instead of ./app/views/feed/index.  I have never worked in Ruby or with Rails before, so this might be caused by a configuration issue on my end, or there may be a different/preferred syntax for the 'render' calls, but this seems to do the trick.

In order to re-use the feed view with the status controller (as I believe was the intention) , the variable names in the status controller have been updated to match those in the feed controller and the feed templates.

With this patch, the behavior and output of status requests are now the same as api.thingspeak.com.
